### PR TITLE
Read API key from env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ pip install tk pillow requests easygui openai
    - All images will be removed from the display.
 
 ## Notes
-- Ensure that you have a functional OpenAI API key and replace `"sk-xxx"` with your actual API key in the script.
+- Ensure that you have a functional OpenAI API key. The application will use the value of the `OPENAI_API_KEY` environment variable if set, otherwise you will be prompted to provide the key at runtime.
 
 ## License
 This project is licensed under the MIT License. See the LICENSE file for more details.

--- a/dalle_image_editor.py
+++ b/dalle_image_editor.py
@@ -8,8 +8,13 @@ from openai import OpenAI
 import os
 import tempfile
 
+# Read the API key from environment or prompt the user.
+api_key = os.getenv("OPENAI_API_KEY")
+if not api_key:
+    api_key = simpledialog.askstring("API Key", "Enter your OpenAI API key:")
+
 client = OpenAI(
-    api_key="sk-xxx",
+    api_key=api_key,
     base_url="https://api.openai.com/v1/"
 )
 


### PR DESCRIPTION
## Summary
- load OpenAI API key from the `OPENAI_API_KEY` environment variable
- update README to explain the new environment variable

## Testing
- `python -m py_compile dalle_image_editor.py`

------
https://chatgpt.com/codex/tasks/task_b_684d1cb9944483268f639c10f3f004b1